### PR TITLE
Remove YOLOv8 prefix from polygon region label in count3.py

### DIFF
--- a/count3.py
+++ b/count3.py
@@ -33,7 +33,7 @@ except Exception:
 # ---------------- 计数区域（与旧版一致） ----------------
 counting_regions = [
     {
-        'name': 'YOLOv8 Polygon Region',
+        'name': 'Polygon Region',
         'polygon': Polygon([(50, 80), (250, 20), (450, 80), (400, 350), (100, 350)]),
         'counts': 0,
         'seen_ids': set(),


### PR DESCRIPTION
### Motivation
- Remove the hardcoded `YOLOv8` prefix in the top-left polygon region count label so the overlay reads a neutral `Polygon Region` instead of `YOLOv8 Polygon Region`.

### Description
- Update `count3.py` to change the first counting region name from `'YOLOv8 Polygon Region'` to `'Polygon Region'` while leaving the rectangle region label unchanged.

### Testing
- Verified the change with `rg -n "Polygon Region|YOLOv8" count3.py` which shows the polygon label updated and no remaining `YOLOv8` in that entry, and inspected lines with `nl -ba count3.py | sed -n '30,55p'`; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ffd7d8f08331b8f0066ae6bdcb7d)