### PR TITLE
Remove YOLOv8 prefix from top-left region count labels

### DIFF
--- a/count3.py
+++ b/count3.py
@@ -61,7 +61,8 @@ def _draw_counts_top_left(frame, regions, origin=(12, 28), line_gap=28):
     """在左上角统一绘制各区域计数。"""
     x0, y0 = origin
     for i, region in enumerate(regions):
-        text = f"{region['name']}: {region['counts']}"
+        display_name = region['name'].replace('YOLOv8 ', '')
+        text = f"{display_name}: {region['counts']}"
         y = y0 + i * line_gap
         cv2.putText(frame, text, (x0, y), cv2.FONT_HERSHEY_SIMPLEX, 0.75, (255, 255, 255), 2)
 


### PR DESCRIPTION
### Motivation
- Remove the hard-coded `YOLOv8` prefix from on-frame top-left region count annotations so displayed labels are cleaner while keeping internal region names and counting logic unchanged.

### Description
- In `count3.py` updated `_draw_counts_top_left` to strip the `"YOLOv8 "` prefix when composing the overlay text (`display_name = region['name'].replace('YOLOv8 ', '')`), preserving region metadata and counts.

### Testing
- Ran `python -m py_compile count3.py` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d604a1f4cc8331b738808a295da4fd)